### PR TITLE
楽曲詳細でスコア0の記録を表示しないように

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/ViewUserMusicController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserMusicController.php
@@ -61,6 +61,11 @@ class ViewUserMusicController extends Controller
         $prev->damage = 0;
 
         foreach ($score as $key => $value) {
+            if($value->technical_high_score === 0 && $value->battle_high_score === 0 && (float)$value->over_damage_high_score === (float)0){
+                unset($score[$key]);
+                continue;
+            }
+
             $technical[] = (int)($value->technical_high_score);
             $battle[] = (int)($value->battle_high_score);
             $damage[] = (float)$value->over_damage_high_score;


### PR DESCRIPTION
<img width="767" alt="image" src="https://github.com/project-primera/ongeki-score/assets/11350340/cd11e316-c58f-443e-9c3b-18b35df68a18">
見づれえので