### PR TITLE
Singularity のスコアが登録されたりされなかったりする不具合を修正

### DIFF
--- a/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
+++ b/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
@@ -200,15 +200,16 @@ import * as qs from 'qs';
             var $innerContainer3 = $(parseHTML).find(".container3").find("div");
 
             var genre: string = "";
-            await $innerContainer3.each((key, value) => {
+            for (var i = 0; i < $innerContainer3.length; ++i) {
+                var value = $innerContainer3.eq(i);
                 if ($(value).hasClass("p_5 f_20")) {
                     genre = $(value).text();
                 } else if ($(value).hasClass("basic_btn")) {
-                    $(value).each((k, v) => {
-                        this.parseSingleMusic(v, value, difficulty, genre);
-                    });
+                    for (var j = 0; j < $(value).length; ++j) {
+                        await this.parseSingleMusic($(value).eq(j), value, difficulty, genre);
+                    }
                 }
-            });
+            }
         }
 
         private async parseSingleMusic(element, parentElement, difficulty, genre) {


### PR DESCRIPTION
parseScoreData で parseSingleMusic をうまく await できていないため、
parseSingleMusic 内で await に到達した時点以降の処理を待てていません。
parseSingleMusic 内で await しているのは曲名が重複しているケースのみなので、
Singularity の時に問題が発生します。
場合によってスコアが登録されたりされなかったりするようです。

ただ、開発環境で動かしている場合は ETIA 以外が登録されないケースが多いのですが、
実環境では登録されているように見えるため、
負荷によって現象の発生のしやすさが変わっているのかもしれません。
とはいえ直した方が無難だと思います。

each には非同期ラムダ式を指定できないようなので
for ループで置き換えてやればうまく await できます。