### PR TITLE
更新差分にプラチナスコアの情報を追加

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
@@ -61,7 +61,7 @@ class ViewUserProgressController extends Controller
             $filter = "Battle Scoreのみ表示中";
         }
         if($request->filter === "ts"){
-            $filter = "Technical Scoreのみ表示中";
+            $filter = "Technical Score、Platinum Score、クリアランプのみ表示中";
         }
         if($request->filter === "od"){
             $filter = "Over Damageのみ表示中";
@@ -95,26 +95,31 @@ class ViewUserProgressController extends Controller
                 'Basic' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Advanced' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Expert' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Master' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Lunatic' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
             ],
@@ -122,26 +127,31 @@ class ViewUserProgressController extends Controller
                 'Basic' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Advanced' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Expert' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Master' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
                 'Lunatic' => [
                     'battle_high_score' => 0,
                     'technical_high_score' => 0,
+                    'platinum_score' => 0,
                     'over_damage_high_score' => 0,
                 ],
             ]
@@ -192,6 +202,7 @@ class ViewUserProgressController extends Controller
             foreach ($temp as $difficulty => $value) {
                 $score['new'][$difficultyToStr[$difficulty]]['battle_high_score'] += $value->battle_high_score;
                 $score['new'][$difficultyToStr[$difficulty]]['technical_high_score'] += $value->technical_high_score;
+                $score['new'][$difficultyToStr[$difficulty]]['platinum_score'] += $value->platinum_score;
                 $score['new'][$difficultyToStr[$difficulty]]['over_damage_high_score'] += $value->over_damage_high_score;
 
                 if(!array_key_exists($music, $old) || !array_key_exists($difficulty, $old[$music])){
@@ -201,6 +212,7 @@ class ViewUserProgressController extends Controller
                         $progress[$music][$difficulty]["new"] = $value;
                         $progress[$music][$difficulty]["difference"]['battle_high_score'] = "+" . number_format($value->battle_high_score);
                         $progress[$music][$difficulty]["difference"]['technical_high_score'] = "+" . number_format($value->technical_high_score);
+                        $progress[$music][$difficulty]["difference"]['platinum_score'] = "+" . number_format($value->platinum_score);
                         $progress[$music][$difficulty]["difference"]['over_damage_high_score'] = "+" . ($value->over_damage_high_score) . "%";
                         $progress[$music][$difficulty]["difference"]['technical_high_score_rank'] = "N" . " → " . $value->technical_high_score_rank;
                         $progress[$music][$difficulty]["difference"]['is_update_technical_high_score_rank'] = "update";
@@ -218,11 +230,13 @@ class ViewUserProgressController extends Controller
                 }else{
                     $score['old'][$difficultyToStr[$difficulty]]['battle_high_score'] += $old[$music][$difficulty]->battle_high_score;
                     $score['old'][$difficultyToStr[$difficulty]]['technical_high_score'] += $old[$music][$difficulty]->technical_high_score;
+                    $score['old'][$difficultyToStr[$difficulty]]['platinum_score'] += $old[$music][$difficulty]->platinum_score;
                     $score['old'][$difficultyToStr[$difficulty]]['over_damage_high_score'] +=  $old[$music][$difficulty]->over_damage_high_score;
 
                     if($old[$music][$difficulty]->over_damage_high_score < $value->over_damage_high_score
                     || $old[$music][$difficulty]->battle_high_score < $value->battle_high_score
                     || $old[$music][$difficulty]->technical_high_score < $value->technical_high_score
+                    || $old[$music][$difficulty]->platinum_score < $value->platinum_score
                     || $old[$music][$difficulty]->full_bell < $value->full_bell
                     || $old[$music][$difficulty]->full_combo < $value->full_combo
                     || $old[$music][$difficulty]->all_break < $value->all_break){
@@ -232,6 +246,7 @@ class ViewUserProgressController extends Controller
                             $progress[$music][$difficulty]["new"] = $value;
                             $progress[$music][$difficulty]["difference"]['battle_high_score'] = "+" . number_format($value->battle_high_score);
                             $progress[$music][$difficulty]["difference"]['technical_high_score'] = "+" . number_format($value->technical_high_score);
+                            $progress[$music][$difficulty]["difference"]['platinum_score'] = "+" . number_format($value->platinum_score);
                             $progress[$music][$difficulty]["difference"]['over_damage_high_score'] = "+" . ($value->over_damage_high_score) . "%";
                             $progress[$music][$difficulty]["difference"]['technical_high_score_rank'] = "N" . " → " . $value->technical_high_score_rank;
                             $progress[$music][$difficulty]["difference"]['is_update_technical_high_score_rank'] = "update";
@@ -255,7 +270,11 @@ class ViewUserProgressController extends Controller
                                 }
                             }
                             if($request->filter === "ts"){
-                                if($old[$music][$difficulty]->technical_high_score >= $value->technical_high_score){
+                                if($old[$music][$difficulty]->technical_high_score >= $value->technical_high_score
+                                && $old[$music][$difficulty]->platinum_score >= $value->platinum_score
+                                && $old[$music][$difficulty]->full_bell >= $value->full_bell
+                                && $old[$music][$difficulty]->full_combo >= $value->full_combo
+                                && $old[$music][$difficulty]->all_break >= $value->all_break){
                                     continue;
                                 }
                             }
@@ -267,6 +286,7 @@ class ViewUserProgressController extends Controller
 
                             $progress[$music][$difficulty]["difference"]['battle_high_score'] = ($value->battle_high_score - $old[$music][$difficulty]->battle_high_score) != 0 ? "+" . number_format($value->battle_high_score - $old[$music][$difficulty]->battle_high_score) : "";
                             $progress[$music][$difficulty]["difference"]['technical_high_score'] = ($value->technical_high_score - $old[$music][$difficulty]->technical_high_score) != 0 ? "+" . number_format($value->technical_high_score - $old[$music][$difficulty]->technical_high_score) : "";
+                            $progress[$music][$difficulty]["difference"]['platinum_score'] = ($value->platinum_score - $old[$music][$difficulty]->platinum_score) != 0 ? "+" . number_format($value->platinum_score - $old[$music][$difficulty]->platinum_score) : "";
                             $progress[$music][$difficulty]["difference"]['over_damage_high_score'] = ($value->over_damage_high_score - $old[$music][$difficulty]->over_damage_high_score) != 0 ? "+" . ($value->over_damage_high_score - $old[$music][$difficulty]->over_damage_high_score) . "%" : "";
                             $progress[$music][$difficulty]["difference"]['technical_high_score_rank'] = $old[$music][$difficulty]->technical_high_score_rank . " → " . $value->technical_high_score_rank;
                             $progress[$music][$difficulty]["difference"]['is_update_technical_high_score_rank'] = ($old[$music][$difficulty]->technical_high_score_rank != $value->technical_high_score_rank) ? "update" : "";
@@ -288,41 +308,49 @@ class ViewUserProgressController extends Controller
         }
         $score['new']['Total']['battle_high_score'] = $score['new']['Basic']['battle_high_score'] + $score['new']['Advanced']['battle_high_score'] + $score['new']['Expert']['battle_high_score'] + $score['new']['Master']['battle_high_score'] + $score['new']['Lunatic']['battle_high_score'];
         $score['new']['Total']['technical_high_score'] = $score['new']['Basic']['technical_high_score'] + $score['new']['Advanced']['technical_high_score'] + $score['new']['Expert']['technical_high_score'] + $score['new']['Master']['technical_high_score'] + $score['new']['Lunatic']['technical_high_score'];
+        $score['new']['Total']['platinum_score'] = $score['new']['Basic']['platinum_score'] + $score['new']['Advanced']['platinum_score'] + $score['new']['Expert']['platinum_score'] + $score['new']['Master']['platinum_score'] + $score['new']['Lunatic']['platinum_score'];
         $score['new']['Total']['over_damage_high_score'] = $score['new']['Basic']['over_damage_high_score'] + $score['new']['Advanced']['over_damage_high_score'] + $score['new']['Expert']['over_damage_high_score'] + $score['new']['Master']['over_damage_high_score'] + $score['new']['Lunatic']['over_damage_high_score'];
 
         $score['old']['Total']['battle_high_score'] = $score['old']['Basic']['battle_high_score'] + $score['old']['Advanced']['battle_high_score'] + $score['old']['Expert']['battle_high_score'] + $score['old']['Master']['battle_high_score'] + $score['old']['Lunatic']['battle_high_score'];
         $score['old']['Total']['technical_high_score'] = $score['old']['Basic']['technical_high_score'] + $score['old']['Advanced']['technical_high_score'] + $score['old']['Expert']['technical_high_score'] + $score['old']['Master']['technical_high_score'] + $score['old']['Lunatic']['technical_high_score'];
+        $score['old']['Total']['platinum_score'] = $score['old']['Basic']['platinum_score'] + $score['old']['Advanced']['platinum_score'] + $score['old']['Expert']['platinum_score'] + $score['old']['Master']['platinum_score'] + $score['old']['Lunatic']['platinum_score'];
         $score['old']['Total']['over_damage_high_score'] = $score['old']['Basic']['over_damage_high_score'] + $score['old']['Advanced']['over_damage_high_score'] + $score['old']['Expert']['over_damage_high_score'] + $score['old']['Master']['over_damage_high_score'] + $score['old']['Lunatic']['over_damage_high_score'];
 
         $score['difference'] = [
             'Total' => [
                 'battle_high_score' => $score['new']['Total']['battle_high_score'] - $score['old']['Total']['battle_high_score'],
                 'technical_high_score' => $score['new']['Total']['technical_high_score'] - $score['old']['Total']['technical_high_score'],
+                'platinum_score' => $score['new']['Total']['platinum_score'] - $score['old']['Total']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Total']['over_damage_high_score'] - $score['old']['Total']['over_damage_high_score'],
             ],
             'Basic' => [
                 'battle_high_score' => $score['new']['Basic']['battle_high_score'] - $score['old']['Basic']['battle_high_score'],
                 'technical_high_score' => $score['new']['Basic']['technical_high_score'] - $score['old']['Basic']['technical_high_score'],
+                'platinum_score' => $score['new']['Basic']['platinum_score'] - $score['old']['Basic']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Basic']['over_damage_high_score'] - $score['old']['Basic']['over_damage_high_score'],
             ],
             'Advanced' => [
                 'battle_high_score' => $score['new']['Advanced']['battle_high_score'] - $score['old']['Advanced']['battle_high_score'],
                 'technical_high_score' => $score['new']['Advanced']['technical_high_score'] - $score['old']['Advanced']['technical_high_score'],
+                'platinum_score' => $score['new']['Advanced']['platinum_score'] - $score['old']['Advanced']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Advanced']['over_damage_high_score'] - $score['old']['Advanced']['over_damage_high_score'],
             ],
             'Expert' => [
                 'battle_high_score' => $score['new']['Expert']['battle_high_score'] - $score['old']['Expert']['battle_high_score'],
                 'technical_high_score' => $score['new']['Expert']['technical_high_score'] - $score['old']['Expert']['technical_high_score'],
+                'platinum_score' => $score['new']['Expert']['platinum_score'] - $score['old']['Expert']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Expert']['over_damage_high_score'] - $score['old']['Expert']['over_damage_high_score'],
             ],
             'Master' => [
                 'battle_high_score' => $score['new']['Master']['battle_high_score'] - $score['old']['Master']['battle_high_score'],
                 'technical_high_score' => $score['new']['Master']['technical_high_score'] - $score['old']['Master']['technical_high_score'],
+                'platinum_score' => $score['new']['Master']['platinum_score'] - $score['old']['Master']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Master']['over_damage_high_score'] - $score['old']['Master']['over_damage_high_score'],
             ],
             'Lunatic' => [
                 'battle_high_score' => $score['new']['Lunatic']['battle_high_score'] - $score['old']['Lunatic']['battle_high_score'],
                 'technical_high_score' => $score['new']['Lunatic']['technical_high_score'] - $score['old']['Lunatic']['technical_high_score'],
+                'platinum_score' => $score['new']['Lunatic']['platinum_score'] - $score['old']['Lunatic']['platinum_score'],
                 'over_damage_high_score' => $score['new']['Lunatic']['over_damage_high_score'] - $score['old']['Lunatic']['over_damage_high_score'],
             ]
         ];

--- a/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
@@ -58,13 +58,13 @@ class ViewUserProgressController extends Controller
 
         $filter = "";
         if($request->filter === "bs"){
-            $filter = "Battle Scoreのみ表示中";
+            $filter = "Battle Scoreの更新を表示中";
         }
         if($request->filter === "ts"){
-            $filter = "Technical Score、Platinum Score、クリアランプのみ表示中";
+            $filter = "レーティング関連（Technical Score, Platinum Score, クリアランプ）の更新を表示中";
         }
         if($request->filter === "od"){
-            $filter = "Over Damageのみ表示中";
+            $filter = "Over Damageの更新を表示中";
         }
 
         $version = (new ApplicationVersion())->getLatestVersion();

--- a/OngekiScoreLog/resources/assets/sass/_user_progress.scss
+++ b/OngekiScoreLog/resources/assets/sass/_user_progress.scss
@@ -95,7 +95,9 @@
                         color: #d22;
                     }
                     display: inline-block;
-                    padding-left: 2em;
+                    padding-left: 1em;
+                    width: 10em;
+                    text-align: center;
                 }
             }
         }

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -53,9 +53,12 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
         <div>
             <label class="label">更新種別でフィルタリングする</label>
             <a href="{{$url}}">すべて表示</a> /
+            <a href="{{$url}}?filter=ts">レーティング関連の更新</a> /
             <a href="{{$url}}?filter=bs">Battle Score更新</a> /
-            <a href="{{$url}}?filter=ts">レート値更新</a> /
             <a href="{{$url}}?filter=od">Over Damage更新</a>
+        </div>
+
+        <div>
             @if ($filter !== "")
                 <br>{{$filter}}
             @endif
@@ -166,7 +169,7 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="tag {{$value['difference']['old-lamp-is-fb']}}">FB</span>
                                 <span class="tag {{$value['difference']['old-lamp-is-fc']}}">FC</span>
                                 <span class="tag {{$value['difference']['old-lamp-is-ab']}}">AB</span>
-
+                                →
                                 <span class="tag {{$value['difference']['new-lamp-is-fb']}}">FB</span>
                                 <span class="tag {{$value['difference']['new-lamp-is-fc']}}">FC</span>
                                 <span class="tag {{$value['difference']['new-lamp-is-ab']}}">AB</span>

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -146,7 +146,9 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="difference">{{$value['difference']['battle_high_score']}}</span>
                                 <br>
 
-                                <span class="score-title">Over Damage</span><span class="score">{{$value['new']->over_damage_high_score}}%</span><span class="difference">{{$value['difference']['over_damage_high_score']}}</span>
+                                <span class="score-title">Over Damage</span>
+                                <span class="score">{{$value['new']->over_damage_high_score}}%</span>
+                                <span class="difference">{{$value['difference']['over_damage_high_score']}}</span>
                                 <span class="score-rank {{$value['difference']['is_update_over_damage_high_score_rank']}}">{{$value['difference']['over_damage_high_score_rank']}}</span>
                                 <br>
 

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -22,6 +22,10 @@
     <li class="is-active"><a href="/user/{{$id}}/progress">更新差分</a></li>
 @endsection
 
+@php
+$difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
+@endphp
+
 @section('content')
     <article class="box">
         <p>
@@ -50,7 +54,7 @@
             <label class="label">更新種別でフィルタリングする</label>
             <a href="{{$url}}">すべて表示</a> /
             <a href="{{$url}}?filter=bs">Battle Score更新</a> /
-            <a href="{{$url}}?filter=ts">Technical Score更新</a> /
+            <a href="{{$url}}?filter=ts">レート値更新</a> /
             <a href="{{$url}}?filter=od">Over Damage更新</a>
             @if ($filter !== "")
                 <br>{{$filter}}
@@ -87,42 +91,19 @@
                     <tr>
                         <th></th>
                         <th colspan="2">Technical Score</th>
+                        <th colspan="2">Platinum Score</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Total</td>
-                        <td class="right">{{number_format($score['new']['Total']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Total']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Total']['technical_high_score'])}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Basic</td>
-                        <td class="right">{{number_format($score['new']['Basic']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Basic']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Basic']['technical_high_score'])}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Advanced</td>
-                        <td class="right">{{number_format($score['new']['Advanced']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Advanced']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Advanced']['technical_high_score'])}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Expert</td>
-                        <td class="right">{{number_format($score['new']['Expert']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Expert']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Expert']['technical_high_score'])}}</td>
-                    </tr>
-                    <tr>
-                        <td>Master</td>
-                        <td class="right">{{number_format($score['new']['Master']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Master']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Master']['technical_high_score'])}}</td>
-                    </tr>
-                    <tr>
-                        <td>Lunatic</td>
-                        <td class="right">{{number_format($score['new']['Lunatic']['technical_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Lunatic']['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Lunatic']['technical_high_score'])}}</td>
-                    </tr>
+                    @foreach ($difficulties as $difficulty)
+                        <tr>
+                            <td>{{$difficulty}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['technical_high_score'])}}</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['technical_high_score'])}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['platinum_score'])}}</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['platinum_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['platinum_score'])}}</td>
+                        </tr>
+                    @endforeach
                 </tbody>
             </table>
 
@@ -135,51 +116,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Total</td>
-                        <td class="right">{{number_format($score['new']['Total']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Total']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Total']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Total']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Total']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Total']['over_damage_high_score'], 2) . "%"}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Basic</td>
-                        <td class="right">{{number_format($score['new']['Basic']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Basic']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Basic']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Basic']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Basic']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Basic']['over_damage_high_score'], 2) . "%"}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Advanced</td>
-                        <td class="right">{{number_format($score['new']['Advanced']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Advanced']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Advanced']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Advanced']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Advanced']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Advanced']['over_damage_high_score'], 2) . "%"}}</td>
-
-                    </tr>
-                    <tr>
-                        <td>Expert</td>
-                        <td class="right">{{number_format($score['new']['Expert']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Expert']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Expert']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Expert']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Expert']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Expert']['over_damage_high_score'], 2) . "%"}}</td>
-                    </tr>
-                    <tr>
-                        <td>Master</td>
-                        <td class="right">{{number_format($score['new']['Master']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Master']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Master']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Master']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Master']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Master']['over_damage_high_score'], 2) . "%"}}</td>
-                    </tr>
-                    <tr>
-                        <td>Lunatic</td>
-                        <td class="right">{{number_format($score['new']['Lunatic']['battle_high_score'])}}</td>
-                        <td class="right difference">{{($score['difference']['Lunatic']['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference']['Lunatic']['battle_high_score'])}}</td>
-                        <td class="right">{{number_format($score['new']['Lunatic']['over_damage_high_score'], 2)}}%</td>
-                        <td class="right difference">{{($score['difference']['Lunatic']['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference']['Lunatic']['over_damage_high_score'], 2) . "%"}}</td>
-                    </tr>
+                    @foreach ($difficulties as $difficulty)
+                        <tr>
+                            <td>{{$difficulty}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['battle_high_score'])}}</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['battle_high_score'])}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['over_damage_high_score'], 2)}}%</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference'][$difficulty]['over_damage_high_score'], 2) . "%"}}</td>
+                        </tr>
+                    @endforeach
                 </tbody>
             </table>
 
@@ -207,17 +152,22 @@
                                 <span class="score-rank {{$value['difference']['is_update_technical_high_score_rank']}}">{{$value['difference']['technical_high_score_rank']}}</span>
                                 <br>
 
+                                <span class="score-title">Platinum Score</span>
+                                <span class="score">{{number_format($value['new']->platinum_score)}}</span>
+                                <span class="difference">{{$value['difference']['platinum_score']}}</span>
+                                <br>
+
                                 <span class="score-title">Over Damage</span><span class="score">{{$value['new']->over_damage_high_score}}%</span><span class="difference">{{$value['difference']['over_damage_high_score']}}</span>
                                 <span class="score-rank {{$value['difference']['is_update_over_damage_high_score_rank']}}">{{$value['difference']['over_damage_high_score_rank']}}</span>
                             </div>
                             <div class="lamp-info">
-                                    <span class="tag {{$value['difference']['old-lamp-is-fb']}}">FB</span>
-                                    <span class="tag {{$value['difference']['old-lamp-is-fc']}}">FC</span>
-                                    <span class="tag {{$value['difference']['old-lamp-is-ab']}}">AB</span>
-                                    →
-                                    <span class="tag {{$value['difference']['new-lamp-is-fb']}}">FB</span>
-                                    <span class="tag {{$value['difference']['new-lamp-is-fc']}}">FC</span>
-                                    <span class="tag {{$value['difference']['new-lamp-is-ab']}}">AB</span>
+                                <span class="tag {{$value['difference']['old-lamp-is-fb']}}">FB</span>
+                                <span class="tag {{$value['difference']['old-lamp-is-fc']}}">FC</span>
+                                <span class="tag {{$value['difference']['old-lamp-is-ab']}}">AB</span>
+
+                                <span class="tag {{$value['difference']['new-lamp-is-fb']}}">FB</span>
+                                <span class="tag {{$value['difference']['new-lamp-is-fc']}}">FC</span>
+                                <span class="tag {{$value['difference']['new-lamp-is-ab']}}">AB</span>
                             </div>
                         </div>
                         <hr>

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -90,27 +90,6 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                 <thead>
                     <tr>
                         <th></th>
-                        <th colspan="2">Technical Score</th>
-                        <th colspan="2">Platinum Score</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach ($difficulties as $difficulty)
-                        <tr>
-                            <td>{{$difficulty}}</td>
-                            <td class="right">{{number_format($score['new'][$difficulty]['technical_high_score'])}}</td>
-                            <td class="right difference">{{($score['difference'][$difficulty]['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['technical_high_score'])}}</td>
-                            <td class="right">{{number_format($score['new'][$difficulty]['platinum_score'])}}</td>
-                            <td class="right difference">{{($score['difference'][$difficulty]['platinum_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['platinum_score'])}}</td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
-
-            <table class="table is-narrow user-progress-total-table">
-                <thead>
-                    <tr>
-                        <th></th>
                         <th colspan="2">Battle Score</th>
                         <th colspan="2">Over Damage</th>
                     </tr>
@@ -123,6 +102,27 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                             <td class="right difference">{{($score['difference'][$difficulty]['battle_high_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['battle_high_score'])}}</td>
                             <td class="right">{{number_format($score['new'][$difficulty]['over_damage_high_score'], 2)}}%</td>
                             <td class="right difference">{{($score['difference'][$difficulty]['over_damage_high_score'] === 0.0) ? "" : "+" . number_format($score['difference'][$difficulty]['over_damage_high_score'], 2) . "%"}}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+
+            <table class="table is-narrow user-progress-total-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th colspan="2">Technical Score</th>
+                        <th colspan="2">Platinum Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($difficulties as $difficulty)
+                        <tr>
+                            <td>{{$difficulty}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['technical_high_score'])}}</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['technical_high_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['technical_high_score'])}}</td>
+                            <td class="right">{{number_format($score['new'][$difficulty]['platinum_score'])}}</td>
+                            <td class="right difference">{{($score['difference'][$difficulty]['platinum_score'] === 0) ? "" : "+" . number_format($score['difference'][$difficulty]['platinum_score'])}}</td>
                         </tr>
                     @endforeach
                 </tbody>
@@ -146,6 +146,10 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="difference">{{$value['difference']['battle_high_score']}}</span>
                                 <br>
 
+                                <span class="score-title">Over Damage</span><span class="score">{{$value['new']->over_damage_high_score}}%</span><span class="difference">{{$value['difference']['over_damage_high_score']}}</span>
+                                <span class="score-rank {{$value['difference']['is_update_over_damage_high_score_rank']}}">{{$value['difference']['over_damage_high_score_rank']}}</span>
+                                <br>
+
                                 <span class="score-title">Technical Score</span>
                                 <span class="score">{{number_format($value['new']->technical_high_score)}}</span>
                                 <span class="difference">{{$value['difference']['technical_high_score']}}</span>
@@ -155,10 +159,6 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="score-title">Platinum Score</span>
                                 <span class="score">{{number_format($value['new']->platinum_score)}}</span>
                                 <span class="difference">{{$value['difference']['platinum_score']}}</span>
-                                <br>
-
-                                <span class="score-title">Over Damage</span><span class="score">{{$value['new']->over_damage_high_score}}%</span><span class="difference">{{$value['difference']['over_damage_high_score']}}</span>
-                                <span class="score-rank {{$value['difference']['is_update_over_damage_high_score_rank']}}">{{$value['difference']['over_damage_high_score_rank']}}</span>
                             </div>
                             <div class="lamp-info">
                                 <span class="tag {{$value['difference']['old-lamp-is-fb']}}">FB</span>


### PR DESCRIPTION
更新差分にプラチナスコア (PS) の情報を追加しました。
PS のみが変化した場合も表示されるようになります。

フィルタは「Technical Score更新」を「レート値更新」に変更し、
レートに絡む要素（TS、PS、ランプ）のいずれかが更新されたものを表示するフィルタに変更しました。
フィルタを増やしても分かりにくくなりそうというのもありますが、
多分需要が一番多いのがこのフィルタだと思います。
